### PR TITLE
Fix: Don't try to redefine bool on C99 and higher

### DIFF
--- a/extract-xiso.c
+++ b/extract-xiso.c
@@ -369,11 +369,7 @@
 #endif
 
 
-#if ! defined( __cplusplus ) && ! defined( bool )
-	typedef int bool;
-	enum { false, true };
-#endif
-
+#include <stdbool.h>
 
 #ifndef nil
 	#define nil							0


### PR DESCRIPTION
Fixes compiler errors on newer GCC, where `bool` is treated as a keyword.